### PR TITLE
Fix scorrimento pagina mobile luoghi con mappa - scuole.css

### DIFF
--- a/src/assets/css/scuole.css
+++ b/src/assets/css/scuole.css
@@ -14580,6 +14580,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
   right: 0;
   background-color: #f5f5f5;
   padding: 15px 10px;
+  touch-action: auto;
 }
 
 @media (max-width: 991.98px) {


### PR DESCRIPTION
Ripristinato il controllo touch sulla lista di luoghi con "touch-action: auto" sovrascrivendo il "touch-action: none" dalla classe "ps-container"

Fixes [WP#310](https://github.com/italia/design-scuole-wordpress-theme/issues/310)

[Pull request originale WP](https://github.com/italia/design-scuole-wordpress-theme/pull/361)