### PR TITLE
Fix navigazione paragrafi pagine internet a11y

### DIFF
--- a/src/assets/css/scuole.css
+++ b/src/assets/css/scuole.css
@@ -7381,6 +7381,15 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+html, body {
+scroll-padding-top: 9rem!important;
+scroll-behavior: smooth!important;
+	@media (max-width:767.98px){
+		scroll-padding-top: 0rem!important;
+		}
+	}
+}
+
 a {
   color: #455b71;
   text-decoration: none;

--- a/src/assets/js/scuole.js
+++ b/src/assets/js/scuole.js
@@ -153,18 +153,6 @@ $(document).ready(function () {
 }); */
 /* End Mobile Menu Back Text */
 
-/* Scroll Anchor Offset */
-$(function () {
-  $('.scroll-anchor-offset').bind('click', function (event) {
-    var $anchor = $(this);
-    $('html, body').stop().animate({
-      scrollTop: $($anchor.attr('href')).offset().top - 150
-    }, 200, 'easeInOutExpo');
-    event.preventDefault();
-  });
-});
-/* End Scroll Anchor Offset */
-
 /* Accordion */
 $(document).ready(function () {
   if ($(".accordion-wrapper").length) {


### PR DESCRIPTION
Modifica per risolvere il problema di accessibilità che prima non consentiva il corretto spostamento del focus ai paragrafi selezionati nella navigazione delle pagine interne tramite tastiera e screen-readers. Cfr- PR https://github.com/italia/design-scuole-wordpress-theme/pull/430 