### PR TITLE
Update scuole.js

### DIFF
--- a/src/assets/js/scuole.js
+++ b/src/assets/js/scuole.js
@@ -160,7 +160,6 @@ $(function () {
     $('html, body').stop().animate({
       scrollTop: $($anchor.attr('href')).offset().top - 150
     }, 200, 'easeInOutExpo');
-    event.preventDefault();
   });
 });
 /* End Scroll Anchor Offset */


### PR DESCRIPTION
Togliendo il metodo come già suggerito nella https://github.com/italia/design-scuole-wordpress-theme/pull/496 si risolve il problema di accessibilità che non consentiva di spostare il focus sull'elemento selezionato tramite tastiera e tecnologie assistive