### PR TITLE
Restyle Panoramica

### DIFF
--- a/src/scuole-didattica.html
+++ b/src/scuole-didattica.html
@@ -1107,7 +1107,7 @@
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-books"></use>
                         </svg>
                         <div class="card-icon-content d-flex justify-content-center">
-                          <p class="mb-0"><strong>Progetti</strong></p>
+                          <p class="mb-0"><strong>I progetti delle classi</strong></p>
                         </div><!-- /card-icon-content -->
                       </div><!-- /card-body -->
                     </a>
@@ -1121,7 +1121,7 @@
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-timetable"></use>
                         </svg>
                         <div class="card-icon-content d-flex justify-content-center">
-                          <p class="mb-0"><strong>Schede didattiche</strong></p>
+                          <p class="mb-0"><strong>Le schede didattiche</strong></p>
                         </div><!-- /card-icon-content -->
                       </div><!-- /card-body -->
                     </a>
@@ -1134,12 +1134,11 @@
       </section><!-- /section -->
 
       <section class="section bg-white">
-        <section class="section bg-linear-vertical-blue-light">
           <div class="container py-5">
             <div class="row variable-gutters">
               <div class="col">
-                <div class="section-title text-center mb-4">
-                  <h2>I Progetti</h2>
+                <div class="section-title mb-4">
+                  <h2>I progetti delle classi</h2>
                   <p class="mb-4">Scopri i progetti dell'Istituto Federigo Enriques</p>
                   <!-- <div class="clearfix">
                       <a class="btn btn-bluelectric" style="min-width: 200px;" href="#">Scopri</a>
@@ -1148,12 +1147,12 @@
               </div><!-- /col -->
             </div><!-- /row -->
           </div><!-- /container -->
-        </section>
+
 
         <div class="container position-relative slided-top">
           <div class="row variable-gutters pb-5">
             <div class="col-lg-4">
-              <div class="card card-bg bg-blue-light card-thumb-rounded mb-3 h-100">
+              <div class="card card-bg bg-white card-thumb-rounded mb-3 h-100">
                 <div class="card-body pb-0">
                   <div class="card-content">
                     <a class="project-card-title" href="#">
@@ -1184,7 +1183,7 @@
               </div><!-- /card -->
             </div><!-- /col-lg-4 -->
             <div class="col-lg-4">
-              <div class="card card-bg bg-blue-light card-thumb-rounded mb-3 h-100">
+              <div class="card card-bg bg-white card-thumb-rounded mb-3 h-100">
                 <div class="card-body pb-0">
                   <div class="card-content">
                     <a class="project-card-title" href="#">
@@ -1211,7 +1210,7 @@
               </div><!-- /card -->
             </div><!-- /col-lg-4 -->
             <div class="col-lg-4">
-              <div class="card card-bg bg-blue-light card-thumb-rounded mb-3 h-100">
+              <div class="card card-bg bg-white card-thumb-rounded mb-3 h-100">
                 <div class="card-body pb-0">
                   <div class="card-content">
                     <a class="project-card-title" href="#">
@@ -1241,12 +1240,12 @@
   </div><!-- /container -->
   </section>
 
-  <section class="section bg-bluelectricdark py-5">
+  <section class="section bg-white py-5">
     <div class="container">
       <div class="row variable-gutters">
         <div class="col">
           <div class="section-title mb-5">
-            <h3>Schede didattiche</h3>
+            <h2>Le schede didattiche</h2>
           </div>
 
           <!-- CAROSELLO SPLIDE-->
@@ -1256,7 +1255,7 @@
                 <!-- Prima immagine -->
                 <li class="splide__slide">
                   <div class="item">
-                    <div class="card card-horizontal">
+                    <div class="card card-bg card-horizontal">
                       <div class="card-thumb rounded">
                         <a aria-label="approfondisci l'argomento" href="#"><img
                             src="assets/placeholders/placeholder-380x480.jpg" alt=""></a>
@@ -1282,7 +1281,7 @@
                 <!-- Seconda immagine -->
                 <li class="splide__slide">
                   <div class="item">
-                    <div class="card card-horizontal">
+                    <div class="card card-bg card-horizontal">
                       <div class="card-thumb rounded">
                         <a aria-label="approfondisci l'argomento" href="#"><img
                             src="assets/placeholders/placeholder-380x480.jpg" alt=""></a>

--- a/src/scuole-didattica.html
+++ b/src/scuole-didattica.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="assets/css/scuole.css">
 
   <script src="assets/js/modernizr.custom.js"></script>
-
+  
 </head>
 
 <body>
@@ -538,7 +538,9 @@
                         <li class="menu-title">
                           <div class="h3"><a href="#" tabindex="-1" data-element="overview">Panoramica</a></div>
                         </li>
-                        <li>
+                        <li>bluelectricstoria
+
+
                           <a href="#" tabindex="-1">Le notizie</a>
                         </li>
                         <li>
@@ -1090,7 +1092,7 @@
         </div><!-- /container -->
       </section><!-- /section -->
 
-      <section class="section bg-white py-5">
+      <section class="section bg-light py-5">
         <div class="container">
           <div class="row variable-gutters">
             <div class="col-lg-4">
@@ -1133,9 +1135,9 @@
         </div><!-- /container -->
       </section><!-- /section -->
 
-      <section class="section bg-white">
+      <section class="section bg-linear-vertical-blue-light">
           <div class="container py-5">
-            <div class="row variable-gutters">
+            <div class="row variable-gutters">
               <div class="col">
                 <div class="section-title mb-4">
                   <h2>I progetti delle classi</h2>
@@ -1235,12 +1237,12 @@
           </div><!-- /row -->
         </div><!-- /row -->
         <div class="pb-5 text-center">
-          <a class="text-underline" href="#"><strong>Vedi tutti i progetti</strong></a>
+          <a class="text-underline text-dark" href="#"><strong>Vedi tutti i progetti</strong></a>
         </div>
   </div><!-- /container -->
   </section>
 
-  <section class="section bg-white py-5">
+  <section class="section bg-linear-vertical-blue-light py-5">
     <div class="container">
       <div class="row variable-gutters">
         <div class="col">
@@ -1253,16 +1255,16 @@
             <div class="splide__track">
               <ul class="splide__list">
                 <!-- Prima immagine -->
-                <li class="splide__slide">
+                <li class="splide__slide bg-white">
                   <div class="item">
-                    <div class="card card-bg card-horizontal">
+                    <div class="card card-bg card-horizontal p-2">
                       <div class="card-thumb rounded">
                         <a aria-label="approfondisci l'argomento" href="#"><img
                             src="assets/placeholders/placeholder-380x480.jpg" alt=""></a>
                       </div><!-- /card-thumb -->
                       <div class="card-body">
                         <div class="clearfix mb-3">
-                          <a class="btn btn-xs btn-rounded btn-outline-white" href="#">Storia</a>
+                          <a class="badge badge-sm badge-pill badge-outline-bluelectric" href="#">Storia</a>
                         </div>
                         <small class="card-date">25 Settembre 2022</small>
                         <h3><a href="#">Le tecnologie della Prima Guerra Mondiale</a></h3>
@@ -1270,8 +1272,8 @@
                           <li class="icon-duration">30:00 min</li>
                           <li class="icon-comments">12</li>
                         </ul>
-                        <div class="card-author">
-                          <p>da <a href="#">Franco Giani</a></p>
+                        <div class="card-author text-dark">
+                          <p class="text-dark">da <a href="#">Franco Giani</a></p>
                           <span>Professore</span>
                         </div><!-- /card-author -->
                       </div><!-- /card-body -->
@@ -1279,16 +1281,16 @@
                   </div><!-- /item -->
                 </li>
                 <!-- Seconda immagine -->
-                <li class="splide__slide">
+                <li class="splide__slide bg-white">
                   <div class="item">
-                    <div class="card card-bg card-horizontal">
+                    <div class="card card-bg card-horizontal p-2">
                       <div class="card-thumb rounded">
                         <a aria-label="approfondisci l'argomento" href="#"><img
                             src="assets/placeholders/placeholder-380x480.jpg" alt=""></a>
                       </div><!-- /card-thumb -->
                       <div class="card-body">
                         <div class="clearfix mb-3">
-                          <a class="btn btn-xs btn-rounded btn-outline-white" href="#">Storia</a>
+                          <a class="badge badge-sm badge-pill badge-outline-bluelectric" href="#">Storia</a>
                         </div>
                         <small class="card-date">25 Settembre 2022</small>
                         <h3><a href="#">Le tecnologie della Prima Guerra Mondiale</a></h3>
@@ -1296,8 +1298,8 @@
                           <li class="icon-duration">30:00 min</li>
                           <li class="icon-comments">12</li>
                         </ul>
-                        <div class="card-author">
-                          <p>da <a href="#">Franco Giani</a></p>
+                        <div class="card-author text-dark">
+                          <p class="text-dark">da <a href="#">Franco Giani</a></p>
                           <span>Professore</span>
                         </div><!-- /card-author -->
                       </div><!-- /card-body -->
@@ -1305,16 +1307,16 @@
                   </div><!-- /item -->
                 </li>
                 <!-- Video -->
-                <li class="splide__slide">
+                <li class="splide__slide bg-white">
                   <div class="item">
-                    <div class="card card-horizontal">
+                    <div class="card card-bg card-horizontal p-2">
                       <div class="card-thumb rounded">
                         <a aria-label="approfondisci l'argomento" href="#"><img
                             src="assets/placeholders/placeholder-380x480.jpg" alt=""></a>
                       </div><!-- /card-thumb -->
                       <div class="card-body">
                         <div class="clearfix mb-3">
-                          <a class="btn btn-xs btn-rounded btn-outline-white" href="#">Storia</a>
+                          <a class="badge badge-sm badge-pill badge-outline-bluelectric" href="#">Storia</a>
                         </div>
                         <small class="card-date">25 Settembre 2022</small>
                         <h3><a href="#">Le tecnologie della Prima Guerra Mondiale</a></h3>
@@ -1322,8 +1324,8 @@
                           <li class="icon-duration">30:00 min</li>
                           <li class="icon-comments">12</li>
                         </ul>
-                        <div class="card-author">
-                          <p>da <a href="#">Franco Giani</a></p>
+                        <div class="card-author text-dark">
+                          <p class="text-dark">da <a href="#">Franco Giani</a></p>
                           <span>Professore</span>
                         </div><!-- /card-author -->
                       </div><!-- /card-body -->
@@ -1333,14 +1335,14 @@
                 <!-- Quarta immagine -->
                 <li class="splide__slide">
                   <div class="item">
-                    <div class="card card-horizontal">
+                    <div class="card card-bg card-horizontal p-2">
                       <div class="card-thumb rounded">
                         <a aria-label="approfondisci l'argomento" href="#"><img
                             src="assets/placeholders/placeholder-380x480.jpg" alt=""></a>
                       </div><!-- /card-thumb -->
                       <div class="card-body">
                         <div class="clearfix mb-3">
-                          <a class="btn btn-xs btn-rounded btn-outline-white" href="#">Storia</a>
+                          <a class="badge badge-sm badge-pill badge-outline-bluelectric" href="#">Storia</a>
                         </div>
                         <small class="card-date">25 Settembre 2022</small>
                         <h3><a href="#">Le tecnologie della Prima Guerra Mondiale</a></h3>
@@ -1348,8 +1350,8 @@
                           <li class="icon-duration">30:00 min</li>
                           <li class="icon-comments">12</li>
                         </ul>
-                        <div class="card-author">
-                          <p>da <a href="#">Franco Giani</a></p>
+                        <div class="card-author text-dark">
+                          <p class="text-dark">da <a href="#">Franco Giani</a></p>
                           <span>Professore</span>
                         </div><!-- /card-author -->
                       </div><!-- /card-body -->


### PR DESCRIPTION
I titoli delle sezioni e delle card sono stati modificati per riallinearli con il menu ed il resto del sito breadcrumbs del resto del sito.
Corretta la intestazione di "Le schede didattiche" da H3 ad H2.
Eliminato lo sfondo svg dentro la sezione dei progetti poco coerente con il resto della pagina sotto ed i colore blu di sfondo sotto il carosello della didattica. 
Entrambi i titoli delle sezioni sono stati allineati a sinistra.
Aggiunte piccole modifiche grafiche (bordo shadow anche nelle card della didattica) per ottenere un miglior contrasto ed armonizare la grafica complessiva del sito.