### PR TITLE
Allineamento copertine al centro

### DIFF
--- a/src/assets/css/scuole.css
+++ b/src/assets/css/scuole.css
@@ -17974,6 +17974,7 @@ button.icon-text {
   background-color: #455b71;
   background-size: cover;
   background-attachment: scroll;
+  background-position: center;
 }
 
 @media (max-width: 767.98px) {
@@ -18795,6 +18796,7 @@ button.icon-text {
   background-color: #455b71;
   background-size: cover;
   background-attachment: scroll;
+  background-position: center;
 }
 
 @media (max-width: 767.98px) {
@@ -19063,6 +19065,7 @@ button.icon-text {
   background-color: #455b71;
   background-size: cover;
   background-attachment: scroll;
+  background-position: center;
 }
 
 @media (max-width: 767.98px) {


### PR DESCRIPTION
In tutti gli Enti che hanno collaborato con noi, risulta un problema non fornire un criterio che permetta di predisporre copertine che risultino accettabili e visionabili da dispositivi con diversi formati di schermo. Con questa miglioria, si può posizionare il contenuto essenziale al centro della copertina per ottenere il risultato sperato.